### PR TITLE
API now sets the Link header

### DIFF
--- a/tests/test_icap_view.py
+++ b/tests/test_icap_view.py
@@ -44,6 +44,16 @@ class TestIcapView(unittest.TestCase):
 
         self.assertEqual(task_id, expected)
 
+    def test_get_task_link(self):
+        """IcapView - GET on /api/1/inf/icap sets the Link header"""
+        resp = self.app.get('/api/1/inf/icap',
+                            headers={'X-Auth': self.token})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/icap/task/asdf-asdf-asdf>; rel=status'
+
+        self.assertEqual(task_id, expected)
+
     def test_post_task(self):
         """IcapView - POST on /api/1/inf/icap returns a task-id"""
         resp = self.app.post('/api/1/inf/icap',
@@ -54,6 +64,19 @@ class TestIcapView(unittest.TestCase):
 
         task_id = resp.json['content']['task-id']
         expected = 'asdf-asdf-asdf'
+
+        self.assertEqual(task_id, expected)
+
+    def test_post_task_link(self):
+        """IcapView - POST on /api/1/inf/icap sets the Link header"""
+        resp = self.app.post('/api/1/inf/icap',
+                             headers={'X-Auth': self.token},
+                             json={'network': "someLAN",
+                                   'name': "myIcapBox",
+                                   'image': "someVersion"})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/icap/task/asdf-asdf-asdf>; rel=status'
 
         self.assertEqual(task_id, expected)
 
@@ -68,6 +91,17 @@ class TestIcapView(unittest.TestCase):
 
         self.assertEqual(task_id, expected)
 
+    def test_delete_task_link(self):
+        """IcapView - DELETE on /api/1/inf/icap sets the Link header"""
+        resp = self.app.delete('/api/1/inf/icap',
+                               headers={'X-Auth': self.token},
+                               json={'name' : 'myIcapBox'})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/icap/task/asdf-asdf-asdf>; rel=status'
+
+        self.assertEqual(task_id, expected)
+
     def test_image(self):
         """IcapView - GET on the ./image end point returns the a task-id"""
         resp = self.app.get('/api/1/inf/icap/image',
@@ -77,6 +111,11 @@ class TestIcapView(unittest.TestCase):
         expected = 'asdf-asdf-asdf'
 
         self.assertEqual(task_id, expected)
+
+    def test_image_link(self):
+        """IcapView - GET on the ./image end point sets the Link header"""
+        resp = self.app.get('/api/1/inf/icap/image',
+                            headers={'X-Auth': self.token})
 
 
 if __name__ == '__main__':

--- a/vlab_icap_api/lib/views/icap.py
+++ b/vlab_icap_api/lib/views/icap.py
@@ -62,10 +62,13 @@ class IcapView(TaskView):
     def get(self, *args, **kwargs):
         """Display the Icap instances you own"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         task = current_app.celery_app.send_task('icap.show', [username])
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
 
     @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=POST_SCHEMA)
@@ -81,7 +84,7 @@ class IcapView(TaskView):
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
-        resp.headers.add('Link', '<{0}{1}/task/{2}; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
 
     @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
@@ -89,11 +92,14 @@ class IcapView(TaskView):
     def delete(self, *args, **kwargs):
         """Destroy a Icap"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         machine_name = kwargs['body']['name']
         task = current_app.celery_app.send_task('icap.delete', [username, machine_name])
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
 
     @route('/image', methods=["GET"])
     @requires(verify=False, version=(1,2))
@@ -101,7 +107,10 @@ class IcapView(TaskView):
     def image(self, *args, **kwargs):
         """Show available versions of Icap that can be deployed"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         task = current_app.celery_app.send_task('icap.image')
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp


### PR DESCRIPTION
This is the repo that sort of kicked off the whole _use the Link header_ thing.
Other parts of the vLab also use this header, and using it like this seemed like a _"no brainier."

All the branches are bugs because this initial work had a bug with the implementation of the Link header (missing tailing `>` around URI, and forgot to make all methods implement it).

For additional details, checkout https://github.com/willnx/vlab_gateway/pull/3.